### PR TITLE
Listing 3.7 fix docker container name

### DIFF
--- a/bookcode/chapter03.ps1
+++ b/bookcode/chapter03.ps1
@@ -73,7 +73,7 @@ docker network create localnet
 
 # Expose engines and setup shared path for migrations
 docker run -p 1433:1433  --volume shared:/shared:z --name mssql1 --hostname mssql1 --network localnet -d dbatools/sqlinstance
-docker run -p 14333:1433 --volume shared:/shared:z --name mssql --hostname mssql2 --network localnet -d dbatools/sqlinstance2
+docker run -p 14333:1433 --volume shared:/shared:z --name mssql2 --hostname mssql2 --network localnet -d dbatools/sqlinstance2
 
         ###########
         


### PR DESCRIPTION
Purpose: Make listing 3.7 match results from listing 3.8

I found while following along with Chapter 3 on pages 36 & 37

Afterwards, I found that the change in this PR also matches the code found in the article located at https://dbatools.io/docker